### PR TITLE
Added the cwnd metric to the flows

### DIFF
--- a/scratch/.gitignore
+++ b/scratch/.gitignore
@@ -2,6 +2,7 @@
 /*
 !.gitignore
 
+!tcp/
 !nested-subdir/
 !subdir/
 !scratch-simulator.cc

--- a/scratch/tcp/tutorial-app.cc
+++ b/scratch/tcp/tutorial-app.cc
@@ -1,0 +1,99 @@
+/*
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#include "tutorial-app.h"
+
+#include "ns3/applications-module.h"
+
+using namespace ns3;
+
+TutorialApp::TutorialApp()
+    : m_socket(nullptr),
+      m_peer(),
+      m_packetSize(0),
+      m_nPackets(0),
+      m_dataRate(0),
+      m_sendEvent(),
+      m_running(false),
+      m_packetsSent(0)
+{
+}
+
+TutorialApp::~TutorialApp()
+{
+    m_socket = nullptr;
+}
+
+/* static */
+TypeId
+TutorialApp::GetTypeId()
+{
+    static TypeId tid = TypeId("TutorialApp")
+                            .SetParent<Application>()
+                            .SetGroupName("Tutorial")
+                            .AddConstructor<TutorialApp>();
+    return tid;
+}
+
+void
+TutorialApp::Setup(Ptr<Socket> socket,
+                   Address address,
+                   uint32_t packetSize,
+                   uint32_t nPackets,
+                   DataRate dataRate)
+{
+    m_socket = socket;
+    m_peer = address;
+    m_packetSize = packetSize;
+    m_nPackets = nPackets;
+    m_dataRate = dataRate;
+}
+
+void
+TutorialApp::StartApplication()
+{
+    m_running = true;
+    m_packetsSent = 0;
+    m_socket->Bind();
+    m_socket->Connect(m_peer);
+    SendPacket();
+}
+
+void
+TutorialApp::StopApplication()
+{
+    m_running = false;
+
+    if (m_sendEvent.IsPending())
+    {
+        Simulator::Cancel(m_sendEvent);
+    }
+
+    if (m_socket)
+    {
+        m_socket->Close();
+    }
+}
+
+void
+TutorialApp::SendPacket()
+{
+    Ptr<Packet> packet = Create<Packet>(m_packetSize);
+    m_socket->Send(packet);
+
+    if (++m_packetsSent < m_nPackets)
+    {
+        ScheduleTx();
+    }
+}
+
+void
+TutorialApp::ScheduleTx()
+{
+    if (m_running)
+    {
+        Time tNext(Seconds(m_packetSize * 8 / static_cast<double>(m_dataRate.GetBitRate())));
+        m_sendEvent = Simulator::Schedule(tNext, &TutorialApp::SendPacket, this);
+    }
+}

--- a/scratch/tcp/tutorial-app.h
+++ b/scratch/tcp/tutorial-app.h
@@ -1,0 +1,67 @@
+/*
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#ifndef TUTORIAL_APP_H
+#define TUTORIAL_APP_H
+
+#include "ns3/core-module.h"
+#include "ns3/internet-module.h"
+#include "ns3/network-module.h"
+
+namespace ns3
+{
+
+class Application;
+
+/**
+ * Tutorial - a simple Application sending packets.
+ */
+class TutorialApp : public Application
+{
+  public:
+    TutorialApp();
+    ~TutorialApp() override;
+
+    /**
+     * Register this type.
+     * @return The TypeId.
+     */
+    static TypeId GetTypeId();
+
+    /**
+     * Setup the socket.
+     * @param socket The socket.
+     * @param address The destination address.
+     * @param packetSize The packet size to transmit.
+     * @param nPackets The number of packets to transmit.
+     * @param dataRate the data rate to use.
+     */
+    void Setup(Ptr<Socket> socket,
+               Address address,
+               uint32_t packetSize,
+               uint32_t nPackets,
+               DataRate dataRate);
+
+  private:
+    void StartApplication() override;
+    void StopApplication() override;
+
+    /// Schedule a new transmission.
+    void ScheduleTx();
+    /// Send a packet.
+    void SendPacket();
+
+    Ptr<Socket> m_socket;   //!< The transmission socket.
+    Address m_peer;         //!< The destination address.
+    uint32_t m_packetSize;  //!< The packet size.
+    uint32_t m_nPackets;    //!< The number of packets to send.
+    DataRate m_dataRate;    //!< The data rate to use.
+    EventId m_sendEvent;    //!< Send event.
+    bool m_running;         //!< True if the application is running.
+    uint32_t m_packetsSent; //!< The number of packets sent.
+};
+
+} // namespace ns3
+
+#endif /* TUTORIAL_APP_H */


### PR DESCRIPTION
- Change the app used for sending flows from `OnOffApp` to `TutorialApp` from the tutorial so we can add a trace sink to the socket. `OnOffApp` doesn't allow me to access the tcp socket
- Added the trace sink `CwndChange` that writes to a file for each tcp flow the `current time` the `old cwnd value` and `new cwnd value` 